### PR TITLE
Move user programs from NixOS to home-manager

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -98,6 +98,21 @@
         gparted
         mullvad-vpn
         xdg-utils
+        tmux
+        wget
+      ];
+      terminals = [
+        kitty
+      ];
+      launchers = [
+        walker
+        wofi
+      ];
+      notifications = [
+        dunst
+      ];
+      gnomeUtils = [
+        gnome.gnome-tweaks
       ];
       officeTools = [
         libreoffice-still
@@ -109,7 +124,11 @@
       ++ messaging
       ++ multimedia
       ++ officeTools
-      ++ systemUtils;
+      ++ systemUtils
+      ++ terminals
+      ++ launchers
+      ++ notifications
+      ++ gnomeUtils;
 
     file = {
       ".config/1Password/ssh/agent.toml".source = config/1Password/ssh/agent.toml;

--- a/hosts/pulse15-gen1/default.nix
+++ b/hosts/pulse15-gen1/default.nix
@@ -25,13 +25,9 @@
   };
 
   environment.systemPackages = with pkgs; [
-    dunst
     hyprpaper
     hyprpolkitagent
-    kitty
-    walker
     waybar
-    wofi
   ];
 
   fonts.packages = [] ++ builtins.filter lib.attrsets.isDerivation (builtins.attrValues pkgs.nerd-fonts);

--- a/hosts/thinkpad25/default.nix
+++ b/hosts/thinkpad25/default.nix
@@ -31,7 +31,6 @@
   environment.systemPackages = with pkgs; [
     git
     neovim
-    gnome-tweaks
   ];
 
   nixpkgs.config.allowUnfree = true;


### PR DESCRIPTION
## Summary
- Transfer user-specific programs from system-level NixOS configuration to home-manager
- Improve separation of concerns between system and user-level packages
- Organize home-manager packages into logical categories (terminals, launchers, notifications, etc.)

## Changes
- **Common system packages**: Remove tmux, wget (moved to home-manager systemUtils)
- **Pulse15-Gen1**: Remove dunst, kitty, walker, wofi (moved to respective home-manager categories)
- **ThinkPad25**: Remove gnome-tweaks (moved to home-manager gnomeUtils)
- **Home-manager**: Add organized package categories and moved programs

## Test plan
- [ ] Verify NixOS system builds successfully
- [ ] Verify home-manager configuration builds successfully  
- [ ] Test that moved programs are still available after rebuild
- [ ] Confirm system-level components (waybar, hyprland) remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)