### PR TITLE
Switch from SDDM to greetd with tuigreet

### DIFF
--- a/hosts/pulse15-gen1/default.nix
+++ b/hosts/pulse15-gen1/default.nix
@@ -19,9 +19,14 @@
     inputs.niri.overlays.niri
   ];
 
-  services = {
-    displayManager.sddm.enable = true;
-    displayManager.sddm.wayland.enable = true;
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --remember-session --sessions ${config.services.displayManager.sessionData.desktops}/share/wayland-sessions";
+        user = "greeter";
+      };
+    };
   };
 
   programs = {


### PR DESCRIPTION
Replace SDDM display manager with greetd using tuigreet as the greeter for a lighter-weight Wayland session launcher.